### PR TITLE
Fix SendResponse in case of Mandrill return array of recipients

### DIFF
--- a/grails-app/services/org/grails/mandrill/MandrillService.groovy
+++ b/grails-app/services/org/grails/mandrill/MandrillService.groovy
@@ -1,5 +1,5 @@
 package org.grails.mandrill
-
+import grails.converters.JSON
 
 class MandrillService {
 	static transactional = false
@@ -26,14 +26,16 @@ class MandrillService {
 
 		def path = "messages/send.json"
 		def query =  [key:grailsApplication.config.mandrill.apiKey,message:message]
-		return new SendResponse(httpWrapperService.postText(BASE_URL, path ,query))
+		def data = JSON.parse(httpWrapperService.postText(BASE_URL, path ,query)).collect { new SendResponse(it) }
+		return data
 	}
 
 	def sendTemplate(MandrillMessage message, String templateName, List templateContent) {
 		def path = "messages/send-template.json"
 		def query =  [key:grailsApplication.config.mandrill.apiKey, template_name:templateName,
 			template_content:templateContent, message:message]
-		return new SendResponse(httpWrapperService.postText(BASE_URL, path ,query))
+		def data = JSON.parse(httpWrapperService.postText(BASE_URL, path ,query)).collect { new SendResponse(it) }
+		return data
 	}
 
 }

--- a/src/groovy/org/grails/mandrill/SendResponse.groovy
+++ b/src/groovy/org/grails/mandrill/SendResponse.groovy
@@ -1,5 +1,4 @@
 package org.grails.mandrill
-import grails.converters.JSON
 
 class SendResponse {
     String status
@@ -10,7 +9,6 @@ class SendResponse {
     boolean success
 
     SendResponse(data) {
-        data = JSON.parse(data).first()
         this.status = data?.status
         this.message = data?.message
         this.rejectReason = data?.reject_reason


### PR DESCRIPTION
Fix SendResponse in case of Mandrill return array of recipients (not one value). Currently it returns only first element and it's impossible  to use it to collect statistic.
